### PR TITLE
Automated test for issue 31

### DIFF
--- a/fitnesse/pom.xml
+++ b/fitnesse/pom.xml
@@ -51,6 +51,16 @@
 
     <build>
         <finalName>fitnesse</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src/it/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -223,6 +233,82 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>add-it-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/it/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>add-it-resources</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>src/it/resources</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12</version>
+                <executions>
+                    <!--<execution>-->
+                        <!--<id>unit-tests</id>-->
+                        <!--<phase>test</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>test</goal>-->
+                        <!--</goals>-->
+                        <!--<configuration>-->
+                            <!--<skip>true</skip>-->
+                            <!--<excludes>**/*.java</excludes>-->
+                        <!--</configuration>-->
+                    <!--</execution>-->
+                    <execution>
+                        <id>integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/fitnesse/src/it/java/org/jmxdatamart/Extractor/ExtractionWithXmlFileIT.java
+++ b/fitnesse/src/it/java/org/jmxdatamart/Extractor/ExtractionWithXmlFileIT.java
@@ -1,0 +1,21 @@
+package org.jmxdatamart.Extractor;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+
+public class ExtractionWithXmlFileIT {
+
+  @Test
+  public void extractTestWebAppMXBean() throws Exception {
+    InputStream xmlConfiguration = getXmlConfiguration("extractTestWebAppMXBean.xml");
+    Settings settings = Settings.fromXML(xmlConfiguration);
+    Extractor extractor = new Extractor(settings);
+    extractor.extract();
+  }
+
+  private InputStream getXmlConfiguration(String xmlFileName) {
+    return getClass().getResourceAsStream(xmlFileName);
+  }
+
+}

--- a/fitnesse/src/it/resources/org/jmxdatamart/Extractor/extractTestWebAppMXBean.xml
+++ b/fitnesse/src/it/resources/org/jmxdatamart/Extractor/extractTestWebAppMXBean.xml
@@ -1,0 +1,42 @@
+<Settings>
+  <pollingRate>2</pollingRate>
+  <folderLocation>${project.build.directory}/extractTestWebAppMBean</folderLocation>
+  <url>service:jmx:rmi:///jndi/rmi://:8888/jmxrmi</url>
+  <BeanList>
+    <Bean>
+      <name>org.jmxdatamart:Type=TestWebAppMBean</name>
+      <alias>TestWebAppMBean</alias>
+      <AttributeList>
+<!--         <Attribute> -->
+<!--           <dataType>FLOAT</dataType> -->
+<!--           <name>Age</name> -->
+<!--         </Attribute> -->
+        <Attribute>
+          <dataType>INT</dataType>
+          <name>NumberOfInvocations</name>
+        </Attribute>
+        <Attribute>
+          <dataType>FLOAT</dataType>
+          <name>RandomFloat</name>
+        </Attribute>
+        <Attribute>
+          <dataType>STRING</dataType>
+          <name>AsciiString</name>
+        </Attribute>
+        <Attribute>
+          <dataType>STRING</dataType>
+          <name>Latin1String</name>
+        </Attribute>
+        <Attribute>
+          <dataType>STRING</dataType>
+          <name>UnicodeString</name>
+        </Attribute>
+        <Attribute>
+          <dataType>STRING</dataType>
+          <name>AnotherUnicodeString</name>
+        </Attribute>
+      </AttributeList>
+      <enable>true</enable>
+    </Bean>
+  </BeanList>
+</Settings>


### PR DESCRIPTION
I added an automated test that reproduces https://github.com/TeamDewberry/jmxdatamart/issues/31

It's possible that I don't have all of the changes from TeamDewberry/master in my DavidWhitlock/master branch, but I'm pretty sure I've got everything.  And just to make sure that it's not my local environment at fault, I ran a buildhive build against this code:

https://buildhive.cloudbees.com/job/DavidWhitlock/job/jmxdatamart/63/console

The test failed as I expected.

https://buildhive.cloudbees.com/job/DavidWhitlock/job/jmxdatamart/org.jmxdatamart$fitnesse/63/testReport/junit/org.jmxdatamart.Extractor/ExtractionWithXmlFileIT/extractTestWebAppMXBean/

Loaded the appropriate driver
Database /scratch/jenkins/workspace/DavidWhitlock/jmxdatamart/fitnesse/target/extractTestWebAppMBeanExtrator20130223171521 is created.
type not found or user lacks privilege: STRING
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.787 sec <<< FAILURE!
17:15:22.973 [JMX Statistics Extractor] DEBUG org.jmxdatamart.Extractor.Extractor - While extracting MBeans
org.jmxdatamart.common.DBException: Something wrong in the Dynamic Bean: bean table doesn't exists!
    at org.jmxdatamart.Extractor.Bean2DB.dealWithDynamicBean(Bean2DB.java:72) ~[jmx-extractor-1.0-SNAPSHOT.jar:na]
    at org.jmxdatamart.Extractor.Bean2DB.export2DB(Bean2DB.java:91) ~[jmx-extractor-1.0-SNAPSHOT.jar:na]
    at org.jmxdatamart.Extractor.Extractor.extract(Extractor.java:103) ~[jmx-extractor-1.0-SNAPSHOT.jar:na]
    at org.jmxdatamart.Extractor.Extractor$Extract.run(Extractor.java:141) ~[jmx-extractor-1.0-SNAPSHOT.jar:na]
    at java.util.TimerThread.mainLoop(Timer.java:512) [na:1.6.0_30]
    at java.util.TimerThread.run(Timer.java:462) [na:1.6.0_30]

Please pull these changes into the "fix-issue-31" branch for fixing this defect and make sure that it reproduces for you.

Thanks,

Dave
